### PR TITLE
update QgsMessageLog example

### DIFF
--- a/core/qgis-sample-QgsMessageLog.py
+++ b/core/qgis-sample-QgsMessageLog.py
@@ -1,20 +1,21 @@
 # coding: utf-8
-from qgis.core import QgsMessageLog
-
-filename = '/tmp/qgis.log'
+from qgis.core import Qgis, QgsApplication
 
 
 def writelogmessage(message, tag, level):
     with open(filename, 'a') as logfile:
         logfile.write('{}({}): {}'.format(tag, level, message))
 
-QgsMessageLog.instance().messageReceived.connect(writelogmessage)
+filename = '/tmp/qgis.log'
 
-# Use QgsMessageLog to log all the information that you want to save about
-# the execution of your code.
-QgsMessageLog.logMessage("Your plugin code has been executed correctly",
-                         'MyPlugin', QgsMessageLog.INFO)
-QgsMessageLog.logMessage("Your plugin code might have some problems",
-                         level=QgsMessageLog.WARNING)
-QgsMessageLog.logMessage("Your plugin code has crashed!",
-                         level=QgsMessageLog.CRITICAL)
+message_log = QgsApplication.messageLog()
+message_log.messageReceived.connect(writelogmessage)
+
+# Use the QgsMessageLog to log all the information that you want to save
+# about the execution of your code.
+message_log.logMessage("Your plugin code has been executed correctly",
+                         'MyPlugin', Qgis.Info)
+message_log.logMessage("Your plugin code might have some problems",
+                         level=Qgis.Warning)
+message_log.logMessage("Your plugin code has crashed!",
+                         level=Qgis.Critical)


### PR DESCRIPTION
- message level constants are in qgis.core.Qgis now
- QgsMessageLog.instance() method is no more
- QgsMessageLog.logMessage() will automagically create an instance if needed but why not just use the existing one (unless a standalone app was built I guess?)
- Accessing QgsMessageLog.messageReceived will NOT automagically create an instance so it crashed here, so for this we must use an existing instance

This might all be wrong :o)